### PR TITLE
Fix CircleCI "Too long with no output" Error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,13 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.2
 
-defaults: &defaults
-  working_directory: ~/repo
-  docker:
-    - image: circleci/node:latest
-
 jobs:
   build-and-test:
-    <<: *defaults
+    docker:
+      - image: circleci/node:12.4.0
+
+    working_directory: ~/repo
+
     steps:
       - checkout
       - run: npm ci

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "dev": "micro-dev local/index.ts",
-    "test": "xo && tsc && ava",
+    "test": "xo && tsc",
     "coverage": "nyc npm test",
     "coverage:upload": "nyc report --reporter=lcov && codecov",
     "coverage:check": "nyc report && nyc check-coverage --lines 100 --functions 100 --branches 100"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "dev": "micro-dev local/index.ts",
-    "test": "xo && tsc",
+    "test": "xo && tsc && ava --serial",
     "coverage": "nyc npm test",
     "coverage:upload": "nyc report --reporter=lcov && codecov",
     "coverage:check": "nyc report && nyc check-coverage --lines 100 --functions 100 --branches 100"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "dev": "micro-dev local/index.ts",
-    "test": "xo && tsc && ava --serial",
+    "test": "xo && tsc && ava -c 8",
     "coverage": "nyc npm test",
     "coverage:upload": "nyc report --reporter=lcov && codecov",
     "coverage:check": "nyc report && nyc check-coverage --lines 100 --functions 100 --branches 100"


### PR DESCRIPTION
- Fixes recent CircleCI `Too long with no output (exceeded 10m0s)` error.